### PR TITLE
Test package creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# use Bash as the shell when interpreting the Makefile
+SHELL := /bin/bash
+
+.PHONY: all
+all: cookiecutter
+
+.PHONY: cookiecutter
+cookiecutter: directory := $(shell mktemp --directory)
+cookiecutter:
+	cookiecutter --no-input --output-dir=$(directory) .
+	$(MAKE) --directory=$(directory)/package
+	$(MAKE) --directory=$(directory)/package dist distcheck
+	$(RM) --recursive $(directory)

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,6 @@
 {
-  "package_name": "Name of LaTeX package",
+  "package_name": "package",
   "package_description": "Short description of package",
-  "release_date": "Date of initial version [YYYY/MM/DD]",
   "author_name": "Name of author (maintainer)",
   "author_email": "Email of author (maintainer)"
 }

--- a/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}.dtx
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}.dtx
@@ -55,7 +55,7 @@
 % Right brace   \}     Tilde         \~}
 %
 %
-% \changes{0.0.1}{{ '{' }}{{cookiecutter.release_date}}}{Initial version}
+% \changes{0.0.1}{{ '{' }}{% now 'utc', '%Y/%m/%d' %}{{ '}' }}{Initial version}
 %
 % \GetFileInfo{{ '{' }}{{cookiecutter.package_name}}.sty}
 %
@@ -98,7 +98,7 @@
 % Identify package and version.
 %    \begin{macrocode}
 \ProvidesPackage{{ '{' }}{{cookiecutter.package_name}}}[%
-    {{cookiecutter.release_date}} %
+    {% now 'utc', '%Y/%m/%d' %} %
     v0.0.1 %
     {{cookiecutter.package_description}}%
 ]


### PR DESCRIPTION
This change tests that the cookiecutter creates a usable LaTeX
package -- i.e., the package compiles correctly and a valid
distribution archive can be generated (using `make dist`).

The "test" is contained within the Makefile in the root of the
repository. Due to the special characters (i.e., curly braces) in the
file names, `make` cannot process the cookiecutter files directly.
Hence, a package is created using the cookiecutter for the test.

The template variables in `cookiecutter.json` are modified with two
changes. First, the default for the package name is now simply
"package" to avoid an awkward path (mixed case and spaces) when the
package is created. Second, the release date is removed in favor of
using the current date, which is probably correct in most cases.