### PR TITLE
Revise README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,6 @@ Usage
 
 Generate a template for a LaTeX package::
 
-    cookiecutter <path-to-this-repository>
+    cookiecutter git@github.com:joel-coffman/latex-cookiecutter.git
 
-Answer the prompts about the package name, initial release date, and
-maintainer.
+Answer the prompts regarding the package name, description, and maintainer.


### PR DESCRIPTION
This change updates the README to use the Git repository rather than
requiring users first to clone and then to specify the path to the
cookiecutter project.