### PR TITLE
Add list of resources to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,3 +18,29 @@ Generate a template for a LaTeX package::
     cookiecutter git@github.com:joel-coffman/latex-cookiecutter.git
 
 Answer the prompts regarding the package name, description, and maintainer.
+
+The following resources may be helpful if you new to writing LaTeX packages:
+
+* LaTeX2e for Class and Package Writers ([LaTeX2006]_)
+* How to Package Your LaTeX Package ([Pakin2015]_)
+* Good things come in little packages: An introduction to writing ``.ins`` and
+  ``.dtx`` files ([Pakin2008]_)
+
+References
+----------
+
+.. [LaTeX2006] The LaTeX Project, "`LaTeX2e for class and package writers`__,"
+   February 2006
+
+.. __: https://www.latex-project.org/help/documentation/clsguide.pdf
+
+.. [Pakin2015] Scott Pakin, "`How to Package Your LaTeX Package`__," September
+   2015
+
+.. __: https://ctan.org/pkg/dtxtut
+
+.. [Pakin2008] Scott Pakin, "`Good things come in little packages: An
+   introduction to writing .ins and .dtx files`__," *TUGboat*, Volume 29, No.
+   2, pp. 305-314, 2008
+
+.. __: http://tug.org/TUGboat/tb29-2/tb92pakin.pdf


### PR DESCRIPTION
Some individuals using this cookiecutter may not be familiar with
writing LaTeX packages (or at least using installer and documented
LaTeX files that are commonly used to distribute packages). Hence,
this change comprises several resources that may be helpful in such
cases.